### PR TITLE
Do not provide the test-helper feature

### DIFF
--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -17,6 +17,4 @@
 
 (require 'winnow)
 
-(provide 'test-helper)
-
 ;;; test-helper.el ends here


### PR DESCRIPTION
"test-helper.el" isn't a library intended to be loaded with `require`.
Instead it is loaded with `load` by `ert-runner` itself.  Because of
that, it is confusing to provide a feature using `provide`.  It also
isn't possible to use `require` to load `test-helper` because that
might, depending on the order of `load-path` load the "test-helper.el"
of another package that used `ert-runner`.

This is also discussed at rejeep/ert-runner.el#38.