### PR TITLE
Support `occur-mode` and other changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,0 @@
-version: 2
-jobs:
-  build:
-    docker:
-      - image: silex/emacs:27-ci-cask
-    working_directory: ~/winnow.el
-    steps:
-      - checkout
-      - run: make

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,12 +30,12 @@ jobs:
         id: cache-cask-packages
         with:
           path: .cask
-          key: cache-cask-packages-000
+          key: cask-packages-${{matrix.emacs_version}}
       - uses: actions/cache@v4
         id: cache-cask-executable
         with:
           path: ~/.cask
-          key: cache-cask-executable-000
+          key: cask-executable-${{matrix.emacs_version}}
       - uses: cask/setup-cask@master
         if: steps.cache-cask-executable.outputs.cache-hit != 'true'
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        emacs_version: [24, 26.1, snapshot]
+        emacs_version: [24.1, 26.1, 30.1]
 
     steps:
       - name: Setup Emacs

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,12 +23,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: cache-cask-packages
         with:
           path: .cask
           key: cache-cask-packages-000
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: cache-cask-executable
         with:
           path: ~/.cask

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        emacs_version: [24, 26.1, snapshot]
+
+    steps:
+      - name: Setup Emacs
+        uses: purcell/setup-emacs@master
+        with:
+          version: ${{ matrix.emacs_version }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run Make
+        run: make

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,5 +23,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: actions/cache@v2
+        id: cache-cask-packages
+        with:
+          path: .cask
+          key: cache-cask-packages-000
+      - uses: actions/cache@v2
+        id: cache-cask-executable
+        with:
+          path: ~/.cask
+          key: cache-cask-executable-000
+      - uses: cask/setup-cask@master
+        if: steps.cache-cask-executable.outputs.cache-hit != 'true'
+        with:
+          version: snapshot
+      - run: echo "$HOME/.cask/bin" >> $GITHUB_PATH
+
       - name: Run Make
         run: make

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        emacs_version: [24.1, 26.1, 30.1]
+        emacs_version:
+          #- 24.1
+          - 26.1
+          - 30.1
 
     steps:
       - name: Setup Emacs

--- a/README.org
+++ b/README.org
@@ -65,6 +65,6 @@ be applicable to other compilation modes. Unfortunately it is not applicable for
 
 * License
 
-Copyright © 2017-2021 Charles L.G. Comstock
+Copyright © 2017-2025 Charles L.G. Comstock
 
 Distributed under the GNU General Public License, version 3

--- a/README.org
+++ b/README.org
@@ -3,7 +3,7 @@
 #+EMAIL: dgtized@gmail.com
 
 [[https://melpa.org/#/winnow][file:https://melpa.org/packages/winnow-badge.svg]]
-[[https://circleci.com/gh/dgtized/winnow.el][https://circleci.com/gh/dgtized/winnow.el.svg?style=svg]]
+file:https://github.com/dgtized/winnow.el/actions/workflows/ci.yaml/badge.svg?branch=master
 
 #+BEGIN_QUOTE
 Winnow - verb

--- a/README.org
+++ b/README.org
@@ -3,7 +3,7 @@
 #+EMAIL: dgtized@gmail.com
 
 [[https://melpa.org/#/winnow][file:https://melpa.org/packages/winnow-badge.svg]]
-file:https://github.com/dgtized/winnow.el/actions/workflows/ci.yaml/badge.svg?branch=master
+[[https://github.com/dgtized/winnow.el/actions][file:https://github.com/dgtized/winnow.el/actions/workflows/ci.yaml/badge.svg?branch=master]]
 
 #+BEGIN_QUOTE
 Winnow - verb

--- a/README.org
+++ b/README.org
@@ -60,8 +60,10 @@ Broadly it should work anything that derives from ~compilation-mode~ so
 #+END_SRC
 
 will enable it everywhere. That should definitely work on ~grep-mode~, and may
-be applicable to other compilation modes. Unfortunately it is not applicable for
-~rspec-mode~ as it currently stands.
+be applicable to other compilation modes. It should work even without a
+compilation mode buffer, if enabled as a minor mode, but it's functionality may
+not be as useful. It has been tested this way with ~occur-mode~ and appears to
+work nicely.
 
 * License
 

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -1,6 +1,6 @@
 ;;; test-helper.el --- Helper for tests              -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2017-2021 Charles L.G. Comstock
+;; Copyright (C) 2017-2025 Charles L.G. Comstock
 
 ;; Author: Charles L.G. Comstock <dgtized@gmail.com>
 

--- a/winnow.el
+++ b/winnow.el
@@ -59,7 +59,7 @@
     (goto-char (point-min))
     (when (compilation-buffer-p (current-buffer))
       (compilation-next-error 1))
-    (point-at-bol 1)))
+    (line-beginning-position 1)))
 
 (defun winnow-results-end ()
   "Find the end position of the compilation output."
@@ -67,7 +67,7 @@
     (goto-char (point-max))
     (when (compilation-buffer-p (current-buffer))
       (compilation-next-error -1))
-    (point-at-bol 2)))
+    (line-beginning-position 2)))
 
 (defun winnow-exclude-lines (regexp &optional rstart rend interactive)
   "Exclude the REGEXP matching lines from the compilation results.

--- a/winnow.el
+++ b/winnow.el
@@ -39,7 +39,10 @@
 
 ;; Enable the package in `ag-mode' with the following:
 ;;
-;;  (add-hook 'ag-mode-hook 'winnow-mode)
+;; (add-hook 'ag-mode-hook 'winnow-mode)
+;;
+;; Or `occur-mode':
+;; (add-hook 'occur-mode-hook 'winnow-mode)
 
 ;;; Todo:
 
@@ -54,14 +57,16 @@
   "Find the start position of the compilation output."
   (save-excursion
     (goto-char (point-min))
-    (compilation-next-error 1)
+    (when (compilation-buffer-p (current-buffer))
+      (compilation-next-error 1))
     (point-at-bol 1)))
 
 (defun winnow-results-end ()
   "Find the end position of the compilation output."
   (save-excursion
     (goto-char (point-max))
-    (compilation-next-error -1)
+    (when (compilation-buffer-p (current-buffer))
+      (compilation-next-error -1))
     (point-at-bol 2)))
 
 (defun winnow-exclude-lines (regexp &optional rstart rend interactive)

--- a/winnow.el
+++ b/winnow.el
@@ -1,6 +1,6 @@
 ;;; winnow.el --- winnow ag/grep results by matching/excluding lines -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2017-2021  Charles L.G. Comstock
+;; Copyright (C) 2017-2025  Charles L.G. Comstock
 
 ;; Author: Charles L.G. Comstock <dgtized@gmail.com>
 ;; Created: 3 Sept 2017


### PR DESCRIPTION
Issue #6 suggested that winnow could work on most buffers by removing the explicit dependency on `compilation-mode` commands. So now it checks to ensure the buffer is derived from `compilation-mode` before using the commands specific to that mode. Otherwise it fails back to `point-min`. 

Also:

- updates the copyright to 2025
- updates some function references that were obsoleted.
- Switch from circleci to github actions