### PR TITLE
Improved compilation-mode check to use derived-mode-p

### DIFF
--- a/README.org
+++ b/README.org
@@ -37,9 +37,10 @@ The following key bindings are enabled:
 The builtin ~highlight-regexp~ (=M-s h r=) can be used to show interesting
 matches in the set.
 
-Basic workflow is to run an ag search (through say ~projectile-ag~), and then use
-~winnow-exclude-lines~ and ~winnow-match-lines~ to keep/flush matching lines in
-the search results. If it's too filtered, just ~recompile~.
+Basic workflow is to run an ag search (through say ~projectile-ag~), and then
+use ~winnow-exclude-lines~ and ~winnow-match-lines~ to keep/flush matching lines
+in the search results. If it's too filtered, just ~recompile~ the buffer to
+restart the original search and re-apply match and exclude filters.
 
 [[https://www.youtube.com/watch?v=BjX8-D-NonY][Emacs Elements: Winnow]] has a longer video demonstration.
 

--- a/README.org
+++ b/README.org
@@ -41,6 +41,8 @@ Basic workflow is to run an ag search (through say ~projectile-ag~), and then us
 ~winnow-exclude-lines~ and ~winnow-match-lines~ to keep/flush matching lines in
 the search results. If it's too filtered, just ~recompile~.
 
+[[https://www.youtube.com/watch?v=BjX8-D-NonY][Emacs Elements: Winnow]] has a longer video demonstration.
+
 * Install
 
 Using the [[https://melpa.milkbox.net][MELPA]] package archive, 

--- a/winnow.el
+++ b/winnow.el
@@ -57,7 +57,7 @@
   "Find the start position of the compilation output."
   (save-excursion
     (goto-char (point-min))
-    (when (compilation-buffer-p (current-buffer))
+    (when (derived-mode-p 'compilation-mode)
       (compilation-next-error 1))
     (line-beginning-position 1)))
 
@@ -65,7 +65,7 @@
   "Find the end position of the compilation output."
   (save-excursion
     (goto-char (point-max))
-    (when (compilation-buffer-p (current-buffer))
+    (when (derived-mode-p 'compilation-mode)
       (compilation-next-error -1))
     (line-beginning-position 2)))
 


### PR DESCRIPTION
Thanks to https://www.youtube.com/@emacselements for pointing out that `(derived-mode-p 'compilation-mode)` is a more reliable check for compilation-mode than `compilation-mode-p`.

Also added a link to the video demonstration on the Emacs Elements channel for additional documentation.